### PR TITLE
Changed port from 9002 to 9001

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -124,7 +124,7 @@ class Server():
         dispatcher.map("/avatar/parameters/*", _recv_packet)
 
         # start the OSC server
-        self.osc = BlockingOSCUDPServer(("127.0.0.1", 9002), dispatcher)
+        self.osc = BlockingOSCUDPServer(("127.0.0.1", 9001), dispatcher)
         print("OSC serving on {}".format(self.osc.server_address)) # While server is active, receive messages
         self.osc.serve_forever()
 


### PR DESCRIPTION
In the [OSC Docs](https://docs.vrchat.com/docs/osc-overview#vrchat-ports) the default port used to read osc messages is 9001. I think it would be good to use the standard port especially for normal users that haven't changed the port with VRChat's launch option.